### PR TITLE
Add support for multiple devices & topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,23 @@ var_dump($response->getStatusCode());
 var_dump($response->getBody()->getContents());
 ```
 
+#Send message to multiple Devices
+
+```
+...
+$message = new Message();
+$message->setPriority('high');
+$message->addRecipient(new Device('_YOUR_DEVICE_TOKEN_'));
+$message->addRecipient(new Device('_YOUR_DEVICE_TOKEN_2_'));
+$message->addRecipient(new Device('_YOUR_DEVICE_TOKEN_3_'));
+$message
+    ->setNotification(new Notification('some title', 'some body'))
+    ->setData(['key' => 'value'])
+;
+...
+```
 #Send message to Topic
-Currently sending to topics only supports a single topic as recipient. Mutliple topic as outlined
-in the google docs don't seem to work, yet.
+
 ```
 use sngrl\PhpFirebaseCloudMessaging\Client;
 use sngrl\PhpFirebaseCloudMessaging\Message;
@@ -69,6 +83,26 @@ $message
 $response = $client->send($message);
 var_dump($response->getStatusCode());
 var_dump($response->getBody()->getContents());
+```
+
+#Send message to multiple Topics
+
+See Firebase documentation for sending to [combinations of multiple topics](https://firebase.google.com/docs/cloud-messaging/topic-messaging#sending_topic_messages_from_the_server).
+
+```
+...
+$message = new Message();
+$message->setPriority('high');
+$message->addRecipient(new Topic('_YOUR_TOPIC_'));
+$message->addRecipient(new Topic('_YOUR_TOPIC_2_'));
+$message->addRecipient(new Topic('_YOUR_TOPIC_3_'));
+$message
+    ->setNotification(new Notification('some title', 'some body'))
+    ->setData(['key' => 'value'])
+    // Will send to devices subscribed to topic 1 AND topic 2 or 3
+    ->setCondition('%s && (%s || %s)')
+;
+...
 ```
 
 #Subscribe user to the topic

--- a/src/Message.php
+++ b/src/Message.php
@@ -10,13 +10,20 @@ use sngrl\PhpFirebaseCloudMessaging\Recipient\Device;
  */
 class Message implements \JsonSerializable
 {
+    /**
+     * Maximum topics and devices: https://firebase.google.com/docs/cloud-messaging/http-server-ref#send-downstream
+     */
+    const MAX_TOPICS = 3;
+    const MAX_DEVICES = 1000;
+    
     private $notification;
-    private $collapseKey;
+    private $collapseKey;    
     private $priority;
     private $data;
     private $recipients = [];
-    private $recipientType;
+    private $recipientType;    
     private $jsonData;
+    private $condition;
 
 
     public function __construct() {
@@ -65,6 +72,22 @@ class Message implements \JsonSerializable
     public function setData(array $data)
     {
         $this->data = $data;
+        return $this;
+    }
+            
+    /**
+     * Specify a condition pattern when sending to combinations of topics
+     * https://firebase.google.com/docs/cloud-messaging/topic-messaging#sending_topic_messages_from_the_server
+     *
+     * Examples:
+     * "%s && %s" > Send to devices subscribed to topic 1 and topic 2
+     * "%s && (%s || %s)" > Send to devices subscribed to topic 1 and topic 2 or 3
+     *
+     * @param string $condition
+     * @return $this
+     */
+    public function setCondition($condition) {
+        $this->condition = $condition;
         return $this;
     }
 
@@ -141,8 +164,15 @@ class Message implements \JsonSerializable
         if (empty($this->recipients)) {
             throw new \UnexpectedValueException('Message must have at least one recipient');
         }
-
-        $jsonData['to'] = $this->createTo();
+        
+        if (count($this->recipients) == 1) {
+            $jsonData['to'] = $this->createTarget();    
+        } elseif ($this->recipientType == Device::class) {
+            $jsonData['registration_ids'] = $this->createTarget();
+        } else {
+            $jsonData['condition'] = $this->createTarget();
+        }       
+        
         if ($this->collapseKey) {
             $jsonData['collapse_key'] = $this->collapseKey;
         }
@@ -159,26 +189,53 @@ class Message implements \JsonSerializable
         return $jsonData;
     }
 
-    private function createTo()
+    private function createTarget()
     {
+        $recipientCount = count($this->recipients);
+        
         switch ($this->recipientType) {
+                
             case Topic::class:
-                if (count($this->recipients) > 1) {
-                    throw new \UnexpectedValueException(
-                        'Currently messages to target multiple topics do not work, but its obviously planned: '.
-                        'https://firebase.google.com/docs/cloud-messaging/topic-messaging#sending_topic_messages_from_the_server'
-                    );
-                }
-                return sprintf('/topics/%s', current($this->recipients)->getName());
+                
+                if ($recipientCount == 1) {
+                    return sprintf('/topics/%s', current($this->recipients)->getName());    
+                    
+                } else if ($recipientCount > self::MAX_TOPICS) {
+                    throw new \OutOfRangeException(sprintf('Message topic limit exceeded. Firebase supports a maximum of %u topics.', self::MAX_TOPICS));
+                    
+                } else if (!$this->condition) {
+                    throw new \InvalidArgumentException('Missing message condition. You must specify a condition pattern when sending to combinations of topics.');
+                    
+                } else if ($recipientCount != substr_count($this->condition, '%s')) {                    
+                    throw new \UnexpectedValueException('The number of message topics must match the number of occurrences of "%s" in the condition pattern.');
+                    
+                } else {
+                    $names = [];
+                    foreach ($this->recipients as $recipient) {
+                        $names[] = vsprintf("'%s' in topics", $recipient->getName());
+                    }
+                    return vsprintf($this->condition, $names);
+                }                
                 break;
-            case Device::class:
-                if (count($this->recipients) == 1) {
-                    return current($this->recipients)->getToken();
-                }
 
+            case Device::class:
+                
+                if ($recipientCount == 1) { 
+                    return current($this->recipients)->getToken();
+                    
+                } else if ($recipientCount > self::MAX_DEVICES) {
+                    throw new \OutOfRangeException(sprintf('Message device limit exceeded. Firebase supports a maximum of %u devices.', self::MAX_DEVICES));
+                    
+                } else {
+                    $ids = [];
+                    foreach ($this->recipients as $recipient) {                        
+                        $ids[] = $recipient->getToken();
+                    }
+                    return $ids;
+                }
                 break;
+                
             default:
-                throw new \UnexpectedValueException('PhpFirebaseCloudMessaging only supports single topic and single device messages yet');
                 break;
         }
         return null;


### PR DESCRIPTION
I needed the ability to send messages to multiple devices (multicast messages). I also added support for conditional topics. Let me know what you think or if you would prefer to implement a different way.

https://firebase.google.com/docs/cloud-messaging/http-server-ref#send-downstream
