### PR TITLE
Poll request contentavailable chage

### DIFF
--- a/src/Notification.php
+++ b/src/Notification.php
@@ -13,6 +13,7 @@ class Notification extends Message
     private $sound;
     private $clickAction;
     private $tag;
+    private $content_available;
 
     public function __construct($title = '', $body = '')
     {
@@ -77,6 +78,12 @@ class Notification extends Message
         return $this;
     }
 
+    public function setContentAvailable($content_available)
+    {
+        $this->content_available = $content_available;
+        return $this;
+    }
+
     public function jsonSerialize()
     {
         $jsonData = $this->getJsonData();
@@ -101,6 +108,9 @@ class Notification extends Message
         if ($this->tag) {
             $jsonData['tag'] = $this->tag;
         }
+        if ($this->content_available) {
+            $jsonData['content_available'] = $this->content_available;
+        }        
         return $jsonData;
     }
 }

--- a/tests/NotificationTest.php
+++ b/tests/NotificationTest.php
@@ -29,4 +29,10 @@ class NotificationTest extends PhpFirebaseCloudMessagingTestCase
         $this->fixture->setIcon('name');
         $this->assertEquals(array('title' => 'foo', 'body' =>'bar', 'icon' => 'name'), $this->fixture->jsonSerialize());
     }
+
+    public function testJsonSerializeWithContentAvailable()
+    {
+        $this->fixture->setContentAvailable(true);
+        $this->assertEquals(array('title' => 'foo', 'body' =>'bar', 'content_available' => true), $this->fixture->jsonSerialize());
+    }
 }


### PR DESCRIPTION
Hi,

I want to cover one of your issue with this pull request:
"I try to add new option in IOS notification its called content_available. How to add it to notification to run it in background"

Unfortunately content_available has to be in Notification for iOS, if it is in data, then it is not working.

This small change should solve the problem.

Thanks.

All the best,
Nandor Huszar